### PR TITLE
add .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,3 @@
+/docs
+/styleguide
+/styleguide.config.js


### PR DESCRIPTION
we must override .gitignore to be able to publish lib as js/es lib.

documentation doesn't need to be in the package (reduce package size)