### PR TITLE
transformer should return null without uast

### DIFF
--- a/src/transformer.js
+++ b/src/transformer.js
@@ -1,6 +1,10 @@
 export const DEFAULT_EXPAND_LEVEL = 2;
 
 function transformer(uastJson, expandLevel = DEFAULT_EXPAND_LEVEL, ...hooks) {
+  if (!uastJson) {
+    return null;
+  }
+
   const tree = {};
   let id = 0;
 

--- a/src/transformer.test.js
+++ b/src/transformer.test.js
@@ -1,0 +1,8 @@
+import transformer from './transformer';
+
+describe('transformer', () => {
+  it('returns null when uast is not present', () => {
+    expect(transformer()).toBeNull();
+    expect(transformer(null)).toBeNull();
+  });
+});


### PR DESCRIPTION
Otherwise, it's almost impossible to identify when there is no uast in component wrapped by `withUASTEditor`