### PR TITLE
add helper to map language name to mime type

### DIFF
--- a/docs/state/helpers.md
+++ b/docs/state/helpers.md
@@ -46,3 +46,28 @@ const pos = getNodePosition(nodeWithoutPosition);
 const pos = getNodePosition(nodeWithStartPosition);
 // pos = { from: { line: N, ch: N }, to: null}
 ```
+
+### languageToMode
+
+Maps language name to MIME Mode recognizable by code-mirror.
+
+Example usage:
+
+```js
+const { languageToMode } = require('uast-viewer');
+
+const langs = ['java', 'bash', 'javascript'];
+
+<table>
+    <tr>
+        <th>Language</th>
+        <th>Mode</th>
+    </tr>
+{langs.map(lang => (
+    <tr key={lang}>
+        <td>{lang}</td>
+        <td>-&gt; {languageToMode(lang)}</td>
+    </tr>)
+)}
+</table>
+```

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -115,3 +115,20 @@ export function makePositionIndexHook(posIndex) {
     return node;
   };
 }
+
+const langToMimeModesMapping = {
+  css: 'text/css',
+  ecmascript: 'text/ecmascript',
+  html: 'text/html',
+  javascript: 'text/javascript',
+  typescript: 'text/typescript',
+  cpp: 'text/x-c++src',
+  xml: 'text/xml',
+  bash: 'text/x-sh',
+  shell: 'text/x-sh'
+};
+
+// maps language name to MIME Mode recognizable by code-mirror
+export function languageToMode(lang) {
+  return langToMimeModesMapping[lang] || `text/x-${lang}`;
+}

--- a/src/index.js
+++ b/src/index.js
@@ -8,7 +8,8 @@ import {
   toggleNodeById,
   highlightNodeById,
   getNodePosition,
-  makePositionIndexHook
+  makePositionIndexHook,
+  languageToMode
 } from './helpers';
 
 export default UASTViewer;
@@ -22,5 +23,6 @@ export {
   PositionIndex,
   makePositionIndexHook,
   Editor,
-  withUASTEditor
+  withUASTEditor,
+  languageToMode
 };


### PR DESCRIPTION
Codemirror defines custom mime types for languages and map them to `mode`.

Example for clike mode:
https://codemirror.net/mode/clike/index.html
> MIME types defined: text/x-csrc (C), text/x-c++src (C++), text/x-java (Java), text/x-csharp (C#), text/x-objectivec (Objective-C), text/x-scala (Scala), text/x-vertex x-shader/x-fragment (shader programs), text/x-squirrel (Squirrel) and text/x-ceylon (Ceylon)

Example for sql:
https://codemirror.net/mode/sql/?mime=text/x-gql
> MIME types defined: text/x-sql, text/x-mysql, text/x-mariadb, text/x-cassandra, text/x-plsql, text/x-mssql, text/x-hive, text/x-pgsql, text/x-gql, text/x-gpsql. text/x-esper. 

Most of the custom types follow rule `text/x-{lang}`. But modes itself have some configuration options like [here](https://codemirror.net/mode/javascript/index.html).

The `mode` option is defined as:
> The mode to use. When not given, this will default to the first mode that was loaded. It may be a string, which either simply names the mode or is a MIME type associated with the mode. Alternatively, it may be an object containing configuration options for the mode, with a name property that names the mode (for example {name: "javascript", json: true}).

So it's easier to support mapping to mime type than to mode itself and let code-mirror to map it to correct mode with correct options.