### PR TITLE
Scroll viewer

### DIFF
--- a/docs/cases/with_source_code.md
+++ b/docs/cases/with_source_code.md
@@ -33,12 +33,8 @@ public class Hello extends GenericServlet {
 function Layout({ editorProps, uastViewerProps }) {
   return (
     <div style={{display: 'flex', height: '300px'}}>
-      <div style={{ width: '50%' }}>
-        <Editor {...editorProps} />
-      </div>
-      <div className="viewer" style={{ width: '50%', overflow: 'auto' }}>
-        <UASTViewer {...uastViewerProps} />
-      </div>
+      <Editor {...editorProps} style={{ width: '50%' }}/>
+      <UASTViewer {...uastViewerProps} />
     </div>
   );
 }

--- a/docs/cases/with_source_code.md
+++ b/docs/cases/with_source_code.md
@@ -2,6 +2,12 @@ _Node: [codemirror](https://codemirror.net/) and [react-codemirror2](https://git
 
 The library provides Source Code Editor and High Ordered Component to connect it to UAST Viewer.
 
+Features:
+
+- Highlight related code on node hover
+- Highlight related node on change of cursor
+- Scroll code to highlighted position on click on node
+
 ```js
 const { Editor, withUASTEditor } = require('uast-viewer');
 
@@ -26,7 +32,7 @@ public class Hello extends GenericServlet {
 // define layout for source code editor and UAST Viewer
 function Layout({ editorProps, uastViewerProps }) {
   return (
-    <div style={{display: 'flex'}}>
+    <div style={{display: 'flex', height: '300px'}}>
       <div style={{ width: '50%' }}>
         <Editor {...editorProps} />
       </div>

--- a/src/components/Editor.js
+++ b/src/components/Editor.js
@@ -55,16 +55,31 @@ class Editor extends Component {
     }
   }
 
+  scrollToPos(pos) {
+    // don't change scroll without position
+    if (!pos) {
+      return;
+    }
+
+    // try to position line in the center of viewport
+    const { clientHeight } = this.editor.getScrollInfo();
+    this.editor.scrollIntoView(pos, clientHeight / 2);
+  }
+
   componentDidMount() {
     this.bookmark.remove();
 
     this.selectCode(this.props.markRange);
+    this.scrollToPos(this.props.scrollToPos);
   }
 
   componentDidUpdate(prevProps) {
     if (prevProps.markRange !== this.props.markRange) {
       this.bookmark.remove();
       this.selectCode(this.props.markRange);
+    }
+    if (prevProps.scrollToPos !== this.props.scrollToPos) {
+      this.scrollToPos(this.props.scrollToPos);
     }
   }
 
@@ -126,6 +141,10 @@ Editor.propTypes = {
       line: PropTypes.number,
       ch: PropTypes.number
     })
+  }),
+  scrollToPos: PropTypes.shape({
+    line: PropTypes.number,
+    ch: PropTypes.number
   }),
   theme: PropTypes.string.isRequired,
   onChange: PropTypes.func,

--- a/src/components/Item.js
+++ b/src/components/Item.js
@@ -1,23 +1,24 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-function Item({ children, hovered, highlighted, ...rest }) {
-  let className = 'uast-item';
+function Item({ children, hovered, highlighted, className, ...rest }) {
+  let newClassName = `${className} uast-item`;
   if (hovered) {
-    className += ' hovered';
+    newClassName += ' hovered';
   }
   if (highlighted) {
-    className += ' highlighted';
+    newClassName += ' highlighted';
   }
 
   return (
-    <div className={className} {...rest}>
+    <div className={newClassName} {...rest}>
       {children}
     </div>
   );
 }
 
 Item.propTypes = {
+  className: PropTypes.string,
   children: PropTypes.node.isRequired,
   hovered: PropTypes.bool,
   highlighted: PropTypes.bool

--- a/src/components/Node.js
+++ b/src/components/Node.js
@@ -3,6 +3,10 @@ import PropTypes from 'prop-types';
 import CollapsibleItem from './CollapsibleItem';
 import { Property, Properties } from './properties';
 
+export function nodeClassById(id) {
+  return `uast-viewer__node-${id}`;
+}
+
 class Node extends Component {
   constructor(props) {
     super(props);
@@ -56,6 +60,7 @@ class Node extends Component {
 
     return (
       <CollapsibleItem
+        className={nodeClassById(node.id)}
         label="Node"
         collapsed={!node.expanded}
         hovered={node.hovered}

--- a/src/components/Node.js
+++ b/src/components/Node.js
@@ -9,6 +9,7 @@ class Node extends Component {
 
     this.handleMouseMove = this.handleMouseMove.bind(this);
     this.handleToggle = this.handleToggle.bind(this);
+    this.handleClick = this.handleClick.bind(this);
   }
 
   handleMouseMove(e) {
@@ -28,8 +29,25 @@ class Node extends Component {
     }
   }
 
+  handleClick(e) {
+    // prevent propagation to parent nodes
+    e.stopPropagation();
+
+    const { id, onClick } = this.props;
+    if (onClick) {
+      onClick(id);
+    }
+  }
+
   render() {
-    const { id, uast, showLocations, onToggle, onMouseMove } = this.props;
+    const {
+      id,
+      uast,
+      showLocations,
+      onToggle,
+      onClick,
+      onMouseMove
+    } = this.props;
     const node = uast[id];
 
     if (!node) {
@@ -44,6 +62,7 @@ class Node extends Component {
         highlighted={node.highlighted}
         toggle={this.handleToggle}
         onMouseMove={this.handleMouseMove}
+        onClick={this.handleClick}
       >
         <Property name="internal_type" value={node.InternalType} />
         <Properties properties={node.Properties} />
@@ -61,6 +80,7 @@ class Node extends Component {
           showLocations={showLocations}
           onToggle={onToggle}
           onMouseMove={onMouseMove}
+          onClick={onClick}
         />
       </CollapsibleItem>
     );
@@ -72,7 +92,8 @@ Node.propTypes = {
   uast: PropTypes.object.isRequired,
   showLocations: PropTypes.bool,
   onMouseMove: PropTypes.func,
-  onToggle: PropTypes.func
+  onToggle: PropTypes.func,
+  onClick: PropTypes.func
 };
 
 Node.defaultProps = {
@@ -99,7 +120,14 @@ Roles.propTypes = {
 
 class Children extends Component {
   render() {
-    const { items, uast, showLocations, onMouseMove, onToggle } = this.props;
+    const {
+      items,
+      uast,
+      showLocations,
+      onMouseMove,
+      onToggle,
+      onClick
+    } = this.props;
 
     if (!Array.isArray(items)) {
       return null;
@@ -115,6 +143,7 @@ class Children extends Component {
             showLocations={showLocations}
             onMouseMove={onMouseMove}
             onToggle={onToggle}
+            onClick={onClick}
           />
         ))}
       </CollapsibleItem>
@@ -127,7 +156,8 @@ Children.propTypes = {
   items: PropTypes.arrayOf(PropTypes.number),
   showLocations: PropTypes.bool,
   onMouseMove: PropTypes.func,
-  onToggle: PropTypes.func
+  onToggle: PropTypes.func,
+  onClick: PropTypes.func
 };
 
 function coordinates(position) {

--- a/src/components/UASTViewer.js
+++ b/src/components/UASTViewer.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import Node from './Node';
+import Node, { nodeClassById } from './Node';
 import { hoverNodeById } from '../helpers';
 import splitProps from '../splitProps';
 
@@ -17,8 +17,10 @@ class UASTViewer extends Component {
     this.onMouseMove = this.onMouseMove.bind(this);
     this.unHoverNode = this.unHoverNode.bind(this);
     this.onToggle = this.onToggle.bind(this);
+    this.scrollToId = this.scrollToId.bind(this);
 
     this.lastOverId = null;
+    this.el = null;
   }
 
   // TODO(max): make sure there are no problems with this.lastOverId
@@ -31,6 +33,26 @@ class UASTViewer extends Component {
     if (this.props.uast !== nextProps.uast) {
       this.setState({ uast: nextProps.uast });
     }
+  }
+
+  componentDidUpdate(prevProps) {
+    if (this.props.scrollToNode !== prevProps.scrollToNode) {
+      this.scrollToId(this.props.scrollToNode);
+    }
+  }
+
+  scrollToId(id) {
+    if (!id || !this.el) {
+      return;
+    }
+
+    const nodeEl = this.el.getElementsByClassName(nodeClassById(id))[0];
+
+    if (!nodeEl) {
+      return;
+    }
+
+    this.el.scrollTop = nodeEl.offsetTop;
   }
 
   getUast() {
@@ -88,6 +110,9 @@ class UASTViewer extends Component {
       <div
         className="uast-viewer"
         onMouseLeave={this.unHoverNode}
+        ref={r => {
+          this.el = r;
+        }}
         {...childProps}
       >
         {rootIds.map(id => (
@@ -112,6 +137,7 @@ UASTViewer.propTypes = {
   uast: PropTypes.object.isRequired,
   rootIds: PropTypes.arrayOf(PropTypes.number).isRequired,
   showLocations: PropTypes.bool.isRequired,
+  scrollToNode: PropTypes.number,
   onNodeHover: PropTypes.func,
   onNodeToggle: PropTypes.func,
   onNodeClick: PropTypes.func

--- a/src/components/UASTViewer.js
+++ b/src/components/UASTViewer.js
@@ -98,6 +98,7 @@ class UASTViewer extends Component {
             showLocations={showLocations}
             onToggle={this.onToggle}
             onMouseMove={this.onMouseMove}
+            onClick={props.onNodeClick}
           />
         ))}
       </div>
@@ -112,7 +113,8 @@ UASTViewer.propTypes = {
   rootIds: PropTypes.arrayOf(PropTypes.number).isRequired,
   showLocations: PropTypes.bool.isRequired,
   onNodeHover: PropTypes.func,
-  onNodeToggle: PropTypes.func
+  onNodeToggle: PropTypes.func,
+  onNodeClick: PropTypes.func
 };
 
 UASTViewer.defaultProps = {

--- a/src/withUASTEditor.js
+++ b/src/withUASTEditor.js
@@ -19,6 +19,7 @@ function withUASTEditor(WrappedComponent) {
 
       this.onNodeHover = this.onNodeHover.bind(this);
       this.onNodeToggle = this.onNodeToggle.bind(this);
+      this.onNodeClick = this.onNodeClick.bind(this);
       this.onCursorChanged = this.onCursorChanged.bind(this);
     }
 
@@ -39,8 +40,9 @@ function withUASTEditor(WrappedComponent) {
         ),
         // control highlighted node
         lastHighlighted: null,
-        // position of hovered node
-        pos: null
+        // position (line, ch) of nodes
+        hoverPos: null,
+        clickPos: null
       };
     }
 
@@ -52,14 +54,14 @@ function withUASTEditor(WrappedComponent) {
       if (!node) {
         this.setState({
           uast: newUast,
-          pos: null
+          hoverPos: null
         });
         return;
       }
 
-      const pos = getNodePosition(node);
+      const hoverPos = getNodePosition(node);
 
-      this.setState({ uast: newUast, pos });
+      this.setState({ uast: newUast, hoverPos });
     }
 
     onNodeToggle(id) {
@@ -72,6 +74,19 @@ function withUASTEditor(WrappedComponent) {
         }
       };
       this.setState({ uast: newUast });
+    }
+
+    onNodeClick(id) {
+      const { uast } = this.state;
+      const node = uast[id];
+
+      if (!node) {
+        this.setState({ clickPos: null });
+        return;
+      }
+
+      const clickPos = getNodePosition(node);
+      this.setState({ clickPos });
     }
 
     onCursorChanged(cursorPos) {
@@ -98,13 +113,15 @@ function withUASTEditor(WrappedComponent) {
           editorProps={{
             code,
             languageMode,
-            markRange: this.state.pos,
+            markRange: this.state.hoverPos,
+            scrollToPos: this.state.clickPos,
             onCursorChanged: this.onCursorChanged
           }}
           uastViewerProps={{
             uast: this.state.uast,
             onNodeHover: this.onNodeHover,
-            onNodeToggle: this.onNodeToggle
+            onNodeToggle: this.onNodeToggle,
+            onNodeClick: this.onNodeClick
           }}
           {...rest}
         />

--- a/src/withUASTEditor.js
+++ b/src/withUASTEditor.js
@@ -119,6 +119,7 @@ function withUASTEditor(WrappedComponent) {
           }}
           uastViewerProps={{
             uast: this.state.uast,
+            scrollToNode: this.state.lastHighlighted,
             onNodeHover: this.onNodeHover,
             onNodeToggle: this.onNodeToggle,
             onNodeClick: this.onNodeClick

--- a/styles/_viewer.scss
+++ b/styles/_viewer.scss
@@ -1,0 +1,4 @@
+.uast-viewer {
+    overflow: auto;
+    position: relative;
+}

--- a/styles/default-theme.scss
+++ b/styles/default-theme.scss
@@ -1,3 +1,4 @@
 @import 'variables';
 @import 'node';
 @import 'editor';
+@import 'viewer';


### PR DESCRIPTION
Based on #31

Required by bblfsh/dashboard#136

Implements scrolling to a highlighted node (only vertically).
We might want to scroll horizontally to but I'm not sure about it.