### PR TITLE
Add schema property to Node component

### DIFF
--- a/docs/components/Position.md
+++ b/docs/components/Position.md
@@ -1,0 +1,19 @@
+Renders position property:
+
+```js
+<Position name="some position" position={{
+    Offset: 0,
+    Line: 1,
+    Col: 10,
+}} />
+```
+
+```js
+<Position name="some position" position={{
+    Line: 2,
+}} />
+```
+
+```js
+<Position name="some position" />
+```

--- a/src/components/Position.js
+++ b/src/components/Position.js
@@ -1,0 +1,42 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import CollapsibleItem from './CollapsibleItem';
+import { Property } from './properties';
+
+function coordinates(position) {
+  if (!position) {
+    return [];
+  }
+
+  const values = ['Offset', 'Line', 'Col'];
+
+  return values
+    .filter(name => typeof position[name] !== 'undefined')
+    .map((name, i) => (
+      <Property key={i} name={name.toLowerCase()} value={position[name]} />
+    ));
+}
+
+function Position({ name, position }) {
+  const coords = coordinates(position);
+  if (position && coordinates.length > 0) {
+    return (
+      <CollapsibleItem name={name} label="Position">
+        {coords}
+      </CollapsibleItem>
+    );
+  }
+
+  return <Property name={name} value={null} />;
+}
+
+Position.propTypes = {
+  name: PropTypes.string,
+  position: PropTypes.shape({
+    Offset: PropTypes.number,
+    Line: PropTypes.number,
+    Col: PropTypes.number
+  })
+};
+
+export default Position;

--- a/src/components/UASTViewer.js
+++ b/src/components/UASTViewer.js
@@ -103,7 +103,7 @@ class UASTViewer extends Component {
 
   render() {
     const [props, childProps] = splitProps(this.props, UASTViewer);
-    const { showLocations, rootIds } = props;
+    const { showLocations, rootIds, schema } = props;
     const uast = this.getUast();
 
     return (
@@ -120,6 +120,7 @@ class UASTViewer extends Component {
             key={id}
             id={id}
             uast={uast}
+            schema={schema}
             showLocations={showLocations}
             onToggle={this.onToggle}
             onMouseMove={this.onMouseMove}
@@ -136,6 +137,7 @@ UASTViewer.propTypes = {
   // don't use PropTypes.shape due to possible extra properties in a node
   uast: PropTypes.object.isRequired,
   rootIds: PropTypes.arrayOf(PropTypes.number).isRequired,
+  schema: PropTypes.array,
   showLocations: PropTypes.bool.isRequired,
   scrollToNode: PropTypes.number,
   onNodeHover: PropTypes.func,

--- a/src/components/properties.js
+++ b/src/components/properties.js
@@ -33,20 +33,27 @@ Property.propTypes = {
   value: PropTypes.any
 };
 
-export function Properties({ properties }) {
+export function Properties({ properties, name, label }) {
   if (!properties || !Object.keys(properties).length) {
     return null;
   }
 
   return (
-    <CollapsibleItem name="properties" label="map<string, string>">
-      {Object.keys(properties).map((name, i) => (
-        <Property key={i} name={name} value={properties[name]} />
+    <CollapsibleItem name={name} label={label}>
+      {Object.keys(properties).map((prop, i) => (
+        <Property key={i} name={prop} value={properties[prop]} />
       ))}
     </CollapsibleItem>
   );
 }
 
 Properties.propTypes = {
+  name: PropTypes.string.isRequired,
+  label: PropTypes.string.isRequired,
   properties: PropTypes.object
+};
+
+Properties.defaultProps = {
+  name: 'properties',
+  label: 'map<string, string>'
 };


### PR DESCRIPTION
It would allow to render any UAST-like tree and simplify usage of non-json data sources.

For example schema for a protobuf source:

```js
const nodeSchema = [
  { name: 'internal_type', attr: n => n.pbNode.getInternalType() },
  {
    name: 'properties',
    type: 'object',
    attr: n =>
      n.pbNode
        .getPropertiesMap()
        .toArray()
        .reduce((acc, [key, value]) => Object.assign(acc, { [key]: value }), {})
  },
  { name: 'token', attr: n => n.pbNode.getToken() },
  {
    name: 'roles',
    type: 'array',
    label: '[]Role',
    attr: n => n.pbNode.getRolesList().map(r => roleToString(r))
  }
];
```

Or made-up UAST like schema:
```js
const nodeSchema = [
  { name: 'type', attr: n => n.type },
  { name: 'debug', attr: n => n.debugInfo },
];
```