### PR TITLE
Use context

### DIFF
--- a/docs/components/Node.md
+++ b/docs/components/Node.md
@@ -1,5 +1,7 @@
 Renders a UAST node recursively.
 
+The component must be wrapped with `TreeContext.Provider` containing flat UAST JSON.
+
 ```js
 const someUast = {
     1: {
@@ -20,7 +22,9 @@ const someUast = {
     }
 };
 
-<Node uast={someUast} id={1} />
+<TreeContext.Provider value={someUast}>
+    <Node id={1} />
+</TreeContext.Provider>
 ```
 
 With location:
@@ -36,5 +40,8 @@ const someUast = {
         expanded: true
     }
 };
-<Node uast={someUast} id={1} showLocations={true} />
+
+<TreeContext.Provider value={someUast}>
+    <Node id={1} showLocations={true} />
+</TreeContext.Provider>
 ```

--- a/docs/components/TreeContext.md
+++ b/docs/components/TreeContext.md
@@ -1,0 +1,3 @@
+Keeps the flat UAST tree.
+
+UASTViewer uses this component internally to render Nodes.

--- a/package.json
+++ b/package.json
@@ -57,8 +57,8 @@
   "peerDependencies": {
     "codemirror": "^5.37.0",
     "prop-types": ">=15.5.7",
-    "react": ">=15.5.7",
+    "react": ">=16.3.0",
     "react-codemirror2": "^5.0.1",
-    "react-dom": ">=15.5.7"
+    "react-dom": ">=16.3.0"
   }
 }

--- a/src/components/CollapsibleItem.js
+++ b/src/components/CollapsibleItem.js
@@ -1,10 +1,10 @@
-import React, { Component } from 'react';
+import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import Item from './Item';
 import { PropertyName } from './properties';
 import splitProps from '../splitProps';
 
-class CollapsibleItem extends Component {
+class CollapsibleItem extends PureComponent {
   constructor(props) {
     super(props);
     // component can be controlled or uncontrolled depends on did we pass collapsed state on init or not

--- a/src/components/TreeContext.js
+++ b/src/components/TreeContext.js
@@ -1,0 +1,5 @@
+import React from 'react';
+
+const TreeContext = React.createContext();
+
+export default TreeContext;

--- a/src/components/UASTViewer.js
+++ b/src/components/UASTViewer.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import Node, { nodeClassById } from './Node';
 import { hoverNodeById } from '../helpers';
 import splitProps from '../splitProps';
+import TreeContext from './TreeContext';
 
 class UASTViewer extends Component {
   constructor(props) {
@@ -115,18 +116,19 @@ class UASTViewer extends Component {
         }}
         {...childProps}
       >
-        {rootIds.map(id => (
-          <Node
-            key={id}
-            id={id}
-            uast={uast}
-            schema={schema}
-            showLocations={showLocations}
-            onToggle={this.onToggle}
-            onMouseMove={this.onMouseMove}
-            onClick={props.onNodeClick}
-          />
-        ))}
+        <TreeContext.Provider value={uast}>
+          {rootIds.map(id => (
+            <Node
+              key={id}
+              id={id}
+              schema={schema}
+              showLocations={showLocations}
+              onToggle={this.onToggle}
+              onMouseMove={this.onMouseMove}
+              onClick={props.onNodeClick}
+            />
+          ))}
+        </TreeContext.Provider>
       </div>
     );
   }


### PR DESCRIPTION
During the extraction of the code from the dashboard huge performance degradation was introduced on purpose. A reminder of the reasons:
- the lib shouldn't depend on redux
- the lib should be compatible with dashboard (react v15.6.1)
- react <16.3.0 didn't have official context support

This PR fix it but requires new react.

Benchmarking of mouse moving over the same nodes with 6x CPU throttling:

Master. Average event takes ~630ms. When I move the mouse faster, react cancels events and doesn't rerender the tree at all:
<img width="1046" alt="screen shot 2018-07-10 at 20 47 45" src="https://user-images.githubusercontent.com/406916/42533193-7c0d4f84-8489-11e8-850e-11c7d73a28a7.png">

This PR. Average event takes ~200ms:
<img width="711" alt="screen shot 2018-07-10 at 21 06 53" src="https://user-images.githubusercontent.com/406916/42533204-81da871a-8489-11e8-8286-c249a0d49f34.png">

Without CPU throttling in this branch, I don't feel any lag anymore.

P.S. But 200ms is way too much even for weak CPU. We will need to improve performance further later.