### PR TITLE
Make position index input agnostic

### DIFF
--- a/src/PositionIndex.test.js
+++ b/src/PositionIndex.test.js
@@ -1,52 +1,42 @@
 import PositionIndex from './PositionIndex';
 
-const mkPos = (Line, Col) => ({ Line, Col });
-const mkNode = (start, end, name) => ({ start, end, name });
-
 describe('PositionIndex', () => {
   describe('add', () => {
     it('does not add a node if it has no end', () => {
       const index = new PositionIndex();
-      index.add({});
+      index.add('node', [1, 1]);
       expect(index.index.length).toBe(0);
     });
 
     it('does not add a node if it has no end line', () => {
       const index = new PositionIndex();
-      index.add({ end: { Col: 1 } });
+      index.add('node', [1, 1], [undefined, 1]);
       expect(index.index.length).toBe(0);
     });
 
     it('does not add a node if it has no end col', () => {
       const index = new PositionIndex();
-      index.add({ end: { Line: 1 } });
+      index.add('node', [1, 1], [1]);
       expect(index.index.length).toBe(0);
     });
 
     it('adds a node with a line and col', () => {
       const index = new PositionIndex();
-      index.add({
-        start: { Line: 1, Col: 1 },
-        end: { Line: 1, Col: 1 }
-      });
+      index.add('node', [1, 1], [1, 1]);
       expect(index.index[1][1].length).toBe(1);
     });
 
     it('does not add a duplicated node', () => {
-      const node = {
-        start: { Line: 1, Col: 1 },
-        end: { Line: 1, Col: 1 }
-      };
       const index = new PositionIndex();
-      index.add(node);
-      index.add(node);
+      index.add('node', [1, 1], [1, 1]);
+      index.add('node', [1, 1], [1, 1]);
       expect(index.index[1][1].length).toBe(1);
     });
 
     it('adds a node to the line if there are other nodes already', () => {
       const index = new PositionIndex();
-      index.add(mkNode(mkPos(1, 1), mkPos(1, 1)));
-      index.add(mkNode(mkPos(1, 2), mkPos(1, 4)));
+      index.add('node1', [1, 1], [1, 1]);
+      index.add('node2', [1, 2], [1, 4]);
 
       expect(index.index[1].length).toBe(3);
       expect(index.index[1][1].length).toBe(1);
@@ -55,8 +45,8 @@ describe('PositionIndex', () => {
 
     it('adds a node to the col if there are other nodes already', () => {
       const index = new PositionIndex();
-      index.add(mkNode(mkPos(1, 1), mkPos(1, 1)));
-      index.add(mkNode(mkPos(1, 1), mkPos(1, 4)));
+      index.add('node1', [1, 1], [1, 1]);
+      index.add('node2', [1, 1], [1, 4]);
 
       expect(index.index[1].length).toBe(2);
       expect(index.index[1][1].length).toBe(2);
@@ -65,9 +55,9 @@ describe('PositionIndex', () => {
 
   describe('get returns the specified node', () => {
     const index = new PositionIndex();
-    index.add(mkNode(mkPos(1, 1), mkPos(2, 10), 'parent'));
-    index.add(mkNode(mkPos(1, 2), mkPos(1, 5), 'child1'));
-    index.add(mkNode(mkPos(1, 6), mkPos(2, 10), 'child2'));
+    index.add('parent', [1, 1], [2, 10]);
+    index.add('child1', [1, 2], [1, 5]);
+    index.add('child2', [1, 6], [2, 10]);
 
     const cases = [
       { line: 1, col: 1, expected: 'parent' },
@@ -80,8 +70,8 @@ describe('PositionIndex', () => {
 
     cases.forEach(c => {
       it(`expecting node at ${c.line}:${c.col} to be ${c.expected}`, () => {
-        const node = index.get(mkPos(c.line, c.col));
-        expect(node.name).toBe(c.expected);
+        const node = index.get(c.line, c.col);
+        expect(node).toBe(c.expected);
       });
     });
   });

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -107,11 +107,9 @@ export function getNodePosition(node) {
 
 export function makePositionIndexHook(posIndex) {
   return function posIndexHook(node) {
-    posIndex.add({
-      id: node.id,
-      start: node.StartPosition,
-      end: node.EndPosition
-    });
+    const start = node.StartPosition || {};
+    const end = node.EndPosition || {};
+    posIndex.add(node.id, [start.Line, start.Col], [end.Line, end.Col]);
     return node;
   };
 }

--- a/src/withUASTEditor.js
+++ b/src/withUASTEditor.js
@@ -90,18 +90,15 @@ function withUASTEditor(WrappedComponent, transformer = defaultTransformer) {
     }
 
     onCursorChanged(cursorPos) {
-      const pos = this.posIndex.get({
-        Line: cursorPos.line + 1,
-        Col: cursorPos.ch + 1
-      });
-      if (!pos) {
+      const nodeId = this.posIndex.get(cursorPos.line + 1, cursorPos.ch + 1);
+      if (!nodeId) {
         return;
       }
       const { uast, lastHighlighted } = this.state;
-      const newUast = highlightNodeById(uast, pos.id, lastHighlighted);
+      const newUast = highlightNodeById(uast, nodeId, lastHighlighted);
       this.setState({
-        uast: expandToNodeId(newUast, pos.id),
-        lastHighlighted: pos.id
+        uast: expandToNodeId(newUast, nodeId),
+        lastHighlighted: nodeId
       });
     }
 


### PR DESCRIPTION
The main change `PositionIndex` doesn't require `node` to be in specific shape but requires additional arguments with start/end position.

But `withUASTEditor` HOC still requires original node properties. It will be fixed later.