### PR TITLE
HOTFIX: remove fqdn for gh pages from CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,5 @@ deploy:
     github-token: $GITHUB_TOKEN
     local-dir: styleguide
     skip-cleanup: true
-    fqdn: uast-viewer.bblf.sh
     on:
       branch: master


### PR DESCRIPTION
Requested by GH support to fix https://uast-viewer.bblf.sh/ 

For now, deleted manually from gh-pages, this will prevent Travis from creating it on next deploy.