### PR TITLE
bookmark fix

### DIFF
--- a/styles/_editor.scss
+++ b/styles/_editor.scss
@@ -17,10 +17,8 @@
         &::before {
             content: '';
             position: absolute;
-            bottom: -5px;
             left: -3px;
             width: 3px;
-            height: 19px;
             border: 1px solid $border-accent;
             border-right-width: 0 !important;
             border-left-width: 2px !important;


### PR DESCRIPTION
Part of #48 

it fixes the problem but no test because it's quite complicated.

<img width="372" alt="screen shot 2018-08-14 at 15 33 05" src="https://user-images.githubusercontent.com/406916/44094845-89711606-9fd7-11e8-98c6-45f189565595.png">


There is a good package for jest to compare screenshots: [jest-image-snapshot](https://github.com/americanexpress/jest-image-snapshot)
But I could find any good package that would allow to take screenshots using [puppeteer](https://github.com/GoogleChrome/puppeteer) without lots of custom webpack configuration.
We might need to implement it ourselves. 