### PR TITLE
allow Properties without name

### DIFF
--- a/src/components/Node.js
+++ b/src/components/Node.js
@@ -87,7 +87,7 @@ class PureNode extends PureComponent {
           <CollapsibleItem
             name={field.name}
             label={field.label}
-            key={field.name}
+            key={field.name || key}
           >
             {value.map((v, i) =>
               isObject(v) ? (

--- a/src/components/Properties.js
+++ b/src/components/Properties.js
@@ -22,7 +22,7 @@ function Properties({ properties, name, label }) {
 }
 
 Properties.propTypes = {
-  name: PropTypes.string.isRequired,
+  name: PropTypes.string,
   label: PropTypes.string.isRequired,
   properties: PropTypes.object
 };


### PR DESCRIPTION
with real UAST sometimes we have properties without name. For example it
can be simple object inside an array.

- isRequired removed from name component prop
- set external key if to the component when name is empty

Signed-off-by: Maxim Sukharev <max@smacker.ru>